### PR TITLE
Add products API

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 1,
+    "name": "Уламжлалт модон сандал",
+    "image": "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=300",
+    "price": 299000,
+    "rating": 4,
+    "reviews": 24,
+    "category": "chairs",
+    "description": "Энгийн боловч бат бөх модон сандал"
+  },
+  {
+    "id": 2,
+    "name": "Гар урлалын ширээ",
+    "image": "https://images.unsplash.com/photo-1598300053091-bc172ad3e9e9?w=300",
+    "price": 459000,
+    "rating": 5,
+    "reviews": 42,
+    "category": "tables",
+    "description": "Гар урласан тав тухтай ширээ"
+  },
+  {
+    "id": 3,
+    "name": "Номын тавиур",
+    "image": "https://images.unsplash.com/photo-1600489000022-c2086d79f9d4?w=300",
+    "price": 199000,
+    "rating": 4,
+    "reviews": 18,
+    "category": "cabinets",
+    "description": "Энгийн номын тавиур"
+  },
+  {
+    "id": 4,
+    "name": "Эвхдэг буйдан",
+    "image": "https://images.unsplash.com/photo-1585559606988-0d574549939f?w=300",
+    "price": 899000,
+    "rating": 4,
+    "reviews": 30,
+    "category": "sofas",
+    "description": "Ор болдог зөөлөн буйдан"
+  },
+  {
+    "id": 5,
+    "name": "Хүүхдийн ор",
+    "image": "https://images.unsplash.com/photo-1585421514287-27d7a4a0ae1b?w=300",
+    "price": 399000,
+    "rating": 5,
+    "reviews": 12,
+    "category": "beds",
+    "description": "Хүүхдийн модон ор"
+  }
+]

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const cors = require('cors')
+const fs = require('fs/promises')
 const mysql = require('mysql2/promise')
 const dotenv = require('dotenv')
 dotenv.config()
@@ -18,6 +19,25 @@ const pool = mysql.createPool({
 })
 
 app.get('/api/health', (req,res)=>res.json({status:'ok'}))
+
+app.get('/api/products', async (_req, res) => {
+  try {
+    const data = await fs.readFile('./data/products.json', 'utf8')
+    res.json(JSON.parse(data))
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+app.get('/api/products/recommended', async (_req, res) => {
+  try {
+    const data = await fs.readFile('./data/products.json', 'utf8')
+    const products = JSON.parse(data).slice(0, 3)
+    res.json(products)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
 
 app.post('/api/:table', async (req,res)=>{
   const {table} = req.params


### PR DESCRIPTION
## Summary
- serve product data from a new `products.json` file
- expose `/api/products` and `/api/products/recommended` endpoints

## Testing
- `npm run build`
- `curl -s http://localhost:3001/api/products`


------
https://chatgpt.com/codex/tasks/task_e_68414b09ac608331938d6bb6e61362ea